### PR TITLE
remove binding on `meta.profile`

### DIFF
--- a/src/fhir/fsh-generated/resources/StructureDefinition-bundle-app-transport-framework.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-bundle-app-transport-framework.json
@@ -53,11 +53,6 @@
         ]
       },
       {
-        "id": "Bundle.meta.profile",
-        "path": "Bundle.meta.profile",
-        "mustSupport": true
-      },
-      {
         "id": "Bundle.identifier",
         "path": "Bundle.identifier",
         "min": 1

--- a/src/fhir/fsh-generated/resources/StructureDefinition-bundle-app-transport-framework.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-bundle-app-transport-framework.json
@@ -55,25 +55,7 @@
       {
         "id": "Bundle.meta.profile",
         "path": "Bundle.meta.profile",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "$this"
-            }
-          ],
-          "rules": "openAtEnd"
-        },
-        "min": 1,
         "mustSupport": true
-      },
-      {
-        "id": "Bundle.meta.profile:atf-profile",
-        "path": "Bundle.meta.profile",
-        "sliceName": "atf-profile",
-        "min": 1,
-        "max": "1",
-        "patternCanonical": "https://gematik.de/fhir/atf/StructureDefinition/bundle-app-transport-framework"
       },
       {
         "id": "Bundle.identifier",

--- a/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
@@ -42,11 +42,6 @@
         "mustSupport": true
       },
       {
-        "id": "MessageHeader.meta.profile",
-        "path": "MessageHeader.meta.profile",
-        "mustSupport": true
-      },
-      {
         "id": "MessageHeader.event[x]",
         "path": "MessageHeader.event[x]",
         "binding": {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
@@ -44,25 +44,7 @@
       {
         "id": "MessageHeader.meta.profile",
         "path": "MessageHeader.meta.profile",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "$this"
-            }
-          ],
-          "rules": "openAtEnd"
-        },
-        "min": 1,
         "mustSupport": true
-      },
-      {
-        "id": "MessageHeader.meta.profile:atf-profile",
-        "path": "MessageHeader.meta.profile",
-        "sliceName": "atf-profile",
-        "min": 1,
-        "max": "1",
-        "patternCanonical": "https://gematik.de/fhir/atf/StructureDefinition/message-header-app-transport"
       },
       {
         "id": "MessageHeader.event[x]",

--- a/src/fhir/guides/ig-atf/Home/Release-Notes.page.md
+++ b/src/fhir/guides/ig-atf/Home/Release-Notes.page.md
@@ -7,4 +7,4 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 | Datum | Version | Kommentar |
 |---|---|---|
 |XXX| 1.0.0 | Initialer Release |
-| 21.02.2024 | 1.0.4 | <ul><li>verpflichtende Angabe von</li><ul><li>`MessageHeader.id`</li><li>`MessageHeader.source`</li><li>`MessageHeader.source.name`</li><li>`MessageHeader.source.software`</li><li>`MessageHeader.source.version`</li><li>`MessageHeader.source.contact`</li><li>`MessageHeader.meta.profile:atf-profile` = `https://gematik.de/fhir/atf/StructureDefinition/message-header-app-transport`</li></ul></ul><br> |
+| 21.02.2024 | 1.0.4 | <ul><li>verpflichtende Angabe von</li><ul><li>`MessageHeader.id`</li><li>`MessageHeader.source`</li><li>`MessageHeader.source.name`</li><li>`MessageHeader.source.software`</li><li>`MessageHeader.source.version`</li><li>`MessageHeader.source.contact`</li></ul></ul><br> |

--- a/src/fhir/input/fsh/profiles/MessageBundle.fsh
+++ b/src/fhir/input/fsh/profiles/MessageBundle.fsh
@@ -7,13 +7,7 @@ Description: "Bundle zum Zusammenfasssen der FHIR-Instanzen, welche in innerhalb
 
 * obeys resolve-references-in-bundle
 
-* meta.profile 1..* MS
-* meta.profile ^slicing.discriminator.type = #value
-* meta.profile ^slicing.discriminator.path = "$this"
-* meta.profile ^slicing.rules = #openAtEnd
-
-* meta.profile contains atf-profile 1..1
-* meta.profile[atf-profile] = "https://gematik.de/fhir/atf/StructureDefinition/bundle-app-transport-framework"
+* meta.profile MS
 
 * identifier 1..
 * identifier.system 1..

--- a/src/fhir/input/fsh/profiles/MessageBundle.fsh
+++ b/src/fhir/input/fsh/profiles/MessageBundle.fsh
@@ -7,8 +7,6 @@ Description: "Bundle zum Zusammenfasssen der FHIR-Instanzen, welche in innerhalb
 
 * obeys resolve-references-in-bundle
 
-* meta.profile MS
-
 * identifier 1..
 * identifier.system 1..
 * identifier.system = "urn:ietf:rfc:3986" (exactly)

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -7,8 +7,6 @@ Description: "MessageHeader des MessageBundles"
 
 * event[x] from ServiceIdentifierVS (required)
 
-* meta.profile MS
-
 * id 1..1 MS
   * ^short = "Eindeutige ID der Nachricht, anzugeben als UUID"
 

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -7,13 +7,7 @@ Description: "MessageHeader des MessageBundles"
 
 * event[x] from ServiceIdentifierVS (required)
 
-* meta.profile 1..* MS
-* meta.profile ^slicing.discriminator.type = #value
-* meta.profile ^slicing.discriminator.path = "$this"
-* meta.profile ^slicing.rules = #openAtEnd
-
-* meta.profile contains atf-profile 1..1
-* meta.profile[atf-profile] = "https://gematik.de/fhir/atf/StructureDefinition/message-header-app-transport"
+* meta.profile MS
 
 * id 1..1 MS
   * ^short = "Eindeutige ID der Nachricht, anzugeben als UUID"


### PR DESCRIPTION
Fordert nicht mehr, dass unter `Bundle.meta.profile` und `MessageHeader.meta.profile` das verwendete Profil angegeben sein muss.