### PR TITLE
Umstellung des MessageHeaders

### DIFF
--- a/fhirpkg.lock.json
+++ b/fhirpkg.lock.json
@@ -1,0 +1,8 @@
+{
+  "updated": "2024-03-05T08:07:33.978633+01:00",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1",
+    "de.basisprofil.r4": "1.4.0"
+  },
+  "missing": {}
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "4.0.1"
   ],
   "name": "de.gematik.fhir.atf",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "A framework for applications that use KIM or TI-Messenger for end to end data transport",
   "author": "gematik",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,12 +1,13 @@
 {
-    "fhirVersions": [
-        "4.0.1"
-    ],
-    "name": "de.gematik.fhir.atf",
-    "version": "1.0.4",
-    "description": "A framework for applications that use KIM or TI-Messenger for end to end data transport",
-    "author": "gematik",
-    "dependencies": {
-        "hl7.fhir.r4.core": "4.0.1"
-    }
+  "fhirVersions": [
+    "4.0.1"
+  ],
+  "name": "de.gematik.fhir.atf",
+  "version": "1.0.4",
+  "description": "A framework for applications that use KIM or TI-Messenger for end to end data transport",
+  "author": "gematik",
+  "dependencies": {
+    "hl7.fhir.r4.core": "4.0.1",
+    "de.basisprofil.r4": "1.4.0"
+  }
 }

--- a/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
+++ b/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
@@ -45,11 +45,11 @@
         },
         "destination": [
           {
-            "endpoint": "https://receiver.example.com/endpoint",
+            "endpoint": "mailto:receiver@example.klaus.kim.telematik",
             "receiver": {
               "identifier": {
-                "system": "http://gematik.de/fhir/sid/KIM-Adresse",
-                "value": "receiver@example.klaus.kim.telematik"
+                "system": "https://gematik.de/fhir/sid/telematik-id",
+                "value": "3-test-receiver"
               },
               "display": "Receiver Example"
             }

--- a/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
+++ b/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
@@ -22,6 +22,16 @@
             "https://gematik.de/fhir/atf/StructureDefinition/message-header-app-transport"
           ]
         },
+        "source": {
+          "contact": {
+            "system": "email",
+            "value": "support@topdoc-systems.de"
+          },
+          "name": "TopDoc Systems",
+          "software": "TopDoc TI",
+          "version": "2.4.5",
+          "endpoint": "mailto:sender@example.peter.kim.telematik"
+        },
         "eventCoding": {
           "code": "atf;Selbsttest",
           "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
@@ -49,17 +59,7 @@
           {
             "reference": "urn:uuid:86a87254-ce15-11ed-afa1-0242ac120004"
           }
-        ],
-        "source": {
-          "name": "TopDoc Systems",
-          "software": "TopDoc TI",
-          "version": "2.4.5",
-          "endpoint": "mailto:sender@example.peter.kim.telematik",
-          "contact": {
-            "system": "email",
-            "value": "support@topdoc-systems.de"
-          }
-        }
+        ]
       }
     },
     {

--- a/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
+++ b/src/fhir/fsh-generated/resources/Bundle-ExampleBundleMessageContainer.json
@@ -26,16 +26,6 @@
           "code": "atf;Selbsttest",
           "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
         },
-        "source": {
-          "endpoint": "https://topdoc-systems.de",
-          "name": "TopDoc Systems",
-          "software": "TopDoc TI",
-          "version": "2.4.5",
-          "contact": {
-            "system": "email",
-            "value": "support@topdoc-systems.de"
-          }
-        },
         "sender": {
           "identifier": {
             "system": "http://gematik.de/fhir/sid/KIM-Adresse",
@@ -59,7 +49,17 @@
           {
             "reference": "urn:uuid:86a87254-ce15-11ed-afa1-0242ac120004"
           }
-        ]
+        ],
+        "source": {
+          "name": "TopDoc Systems",
+          "software": "TopDoc TI",
+          "version": "2.4.5",
+          "endpoint": "mailto:sender@example.peter.kim.telematik",
+          "contact": {
+            "system": "email",
+            "value": "support@topdoc-systems.de"
+          }
+        }
       }
     },
     {

--- a/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
+++ b/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
@@ -6,6 +6,16 @@
       "https://gematik.de/fhir/atf/StructureDefinition/message-header-app-transport"
     ]
   },
+  "source": {
+    "contact": {
+      "system": "email",
+      "value": "support@topdoc-systems.de"
+    },
+    "name": "TopDoc Systems",
+    "software": "TopDoc TI",
+    "version": "2.4.5",
+    "endpoint": "mailto:sender@example.peter.kim.telematik"
+  },
   "eventCoding": {
     "code": "atf;Selbsttest",
     "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
@@ -33,15 +43,5 @@
     {
       "reference": "urn:uuid:86a87254-ce15-11ed-afa1-0242ac120004"
     }
-  ],
-  "source": {
-    "name": "TopDoc Systems",
-    "software": "TopDoc TI",
-    "version": "2.4.5",
-    "endpoint": "mailto:sender@example.peter.kim.telematik",
-    "contact": {
-      "system": "email",
-      "value": "support@topdoc-systems.de"
-    }
-  }
+  ]
 }

--- a/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
+++ b/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
@@ -29,11 +29,11 @@
   },
   "destination": [
     {
-      "endpoint": "https://receiver.example.com/endpoint",
+      "endpoint": "mailto:receiver@example.klaus.kim.telematik",
       "receiver": {
         "identifier": {
-          "system": "http://gematik.de/fhir/sid/KIM-Adresse",
-          "value": "receiver@example.klaus.kim.telematik"
+          "system": "https://gematik.de/fhir/sid/telematik-id",
+          "value": "3-test-receiver"
         },
         "display": "Receiver Example"
       }

--- a/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
+++ b/src/fhir/fsh-generated/resources/MessageHeader-ExampleMessageHeaderAppTransportFramework.json
@@ -10,16 +10,6 @@
     "code": "atf;Selbsttest",
     "system": "https://gematik.de/fhir/atf/CodeSystem/service-identifier-cs"
   },
-  "source": {
-    "endpoint": "https://topdoc-systems.de",
-    "name": "TopDoc Systems",
-    "software": "TopDoc TI",
-    "version": "2.4.5",
-    "contact": {
-      "system": "email",
-      "value": "support@topdoc-systems.de"
-    }
-  },
   "sender": {
     "identifier": {
       "system": "http://gematik.de/fhir/sid/KIM-Adresse",
@@ -43,5 +33,15 @@
     {
       "reference": "urn:uuid:86a87254-ce15-11ed-afa1-0242ac120004"
     }
-  ]
+  ],
+  "source": {
+    "name": "TopDoc Systems",
+    "software": "TopDoc TI",
+    "version": "2.4.5",
+    "endpoint": "mailto:sender@example.peter.kim.telematik",
+    "contact": {
+      "system": "email",
+      "value": "support@topdoc-systems.de"
+    }
+  }
 }

--- a/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
@@ -56,6 +56,13 @@
         "mustSupport": true
       },
       {
+        "id": "MessageHeader.destination.endpoint",
+        "path": "MessageHeader.destination.endpoint",
+        "short": "KIM-Adresse des Empfängers",
+        "comment": "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
+        "mustSupport": true
+      },
+      {
         "id": "MessageHeader.destination.receiver",
         "path": "MessageHeader.destination.receiver",
         "min": 1
@@ -68,8 +75,7 @@
           {
             "code": "Identifier",
             "profile": [
-              "https://gematik.de/fhir/atf/StructureDefinition/identifier-address-kim",
-              "https://gematik.de/fhir/atf/StructureDefinition/identifier-address-tim"
+              "http://fhir.de/StructureDefinition/identifier-telematik-id"
             ]
           }
         ],
@@ -78,7 +84,7 @@
       {
         "id": "MessageHeader.destination.receiver.display",
         "path": "MessageHeader.destination.receiver.display",
-        "short": "Anzeigename der Empfänger Adresse",
+        "short": "Anzeigename des Empfängers",
         "mustSupport": true
       },
       {
@@ -95,8 +101,7 @@
           {
             "code": "Identifier",
             "profile": [
-              "https://gematik.de/fhir/atf/StructureDefinition/identifier-address-kim",
-              "https://gematik.de/fhir/atf/StructureDefinition/identifier-address-tim"
+              "http://fhir.de/StructureDefinition/identifier-telematik-id"
             ]
           }
         ],
@@ -105,7 +110,7 @@
       {
         "id": "MessageHeader.sender.display",
         "path": "MessageHeader.sender.display",
-        "short": "Anzeigename der Absender Adresse",
+        "short": "Anzeigename des Senders",
         "mustSupport": true
       },
       {
@@ -143,8 +148,15 @@
         "id": "MessageHeader.source.contact",
         "path": "MessageHeader.source.contact",
         "short": "Kontaktinformation zum Hersteller",
-        "comment": "Es ist mindestens eine Email anzugeben, um Kontakt mit dem Hersteller herzustellen",
+        "comment": "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden",
         "min": 1,
+        "mustSupport": true
+      },
+      {
+        "id": "MessageHeader.source.endpoint",
+        "path": "MessageHeader.source.endpoint",
+        "short": "KIM-Adresse des Absenders",
+        "comment": "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
         "mustSupport": true
       },
       {

--- a/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
@@ -58,13 +58,14 @@
       {
         "id": "MessageHeader.destination.endpoint",
         "path": "MessageHeader.destination.endpoint",
-        "short": "KIM-Adresse des Empfängers",
-        "comment": "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
+        "short": "Bspw. KIM- oder TIM-Adresse des Empfängers",
+        "comment": "Die FHIR Ressource sieht hier eine URL vor. Bspw. kann hier eine KIM-Adresse genutzt werden. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
         "mustSupport": true
       },
       {
         "id": "MessageHeader.destination.receiver",
         "path": "MessageHeader.destination.receiver",
+        "short": "Telematik-ID des Empfängers",
         "min": 1
       },
       {
@@ -96,6 +97,7 @@
       {
         "id": "MessageHeader.sender.identifier",
         "path": "MessageHeader.sender.identifier",
+        "short": "Telematik-ID des Absenders",
         "min": 1,
         "type": [
           {
@@ -110,7 +112,7 @@
       {
         "id": "MessageHeader.sender.display",
         "path": "MessageHeader.sender.display",
-        "short": "Anzeigename des Senders",
+        "short": "Anzeigename des Absenders",
         "mustSupport": true
       },
       {
@@ -155,14 +157,15 @@
       {
         "id": "MessageHeader.source.endpoint",
         "path": "MessageHeader.source.endpoint",
-        "short": "KIM-Adresse des Absenders",
-        "comment": "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
+        "short": "Bspw. KIM- oder TIM-Adresse des Absenders",
+        "comment": "Die FHIR Ressource sieht hier eine URL vor. Bspw. kann hier eine KIM-Adresse genutzt werden. Diese beginnt mit 'mailto:', da der Datentyp url ist.",
         "mustSupport": true
       },
       {
         "id": "MessageHeader.focus",
         "path": "MessageHeader.focus",
-        "min": 1
+        "min": 1,
+        "mustSupport": true
       }
     ]
   }

--- a/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
+++ b/src/fhir/fsh-generated/resources/StructureDefinition-message-header-app-transport.json
@@ -149,10 +149,15 @@
       {
         "id": "MessageHeader.source.contact",
         "path": "MessageHeader.source.contact",
-        "short": "Kontaktinformation zum Hersteller",
-        "comment": "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden",
+        "short": "E-Mail Kontaktmöglichkeit zum Hersteller",
+        "comment": "Es ist mindestens eine E-Mail anzugeben, um Kontakt mit dem Hersteller herstellen zu können",
         "min": 1,
         "mustSupport": true
+      },
+      {
+        "id": "MessageHeader.source.contact.system",
+        "path": "MessageHeader.source.contact.system",
+        "fixedCode": "email"
       },
       {
         "id": "MessageHeader.source.endpoint",

--- a/src/fhir/guides/ig-atf/Home/Release-Notes.page.md
+++ b/src/fhir/guides/ig-atf/Home/Release-Notes.page.md
@@ -8,3 +8,4 @@ Die erste Ziffer X bezeichnet ein Major-Release und regelt die Gültigkeit von R
 |---|---|---|
 |XXX| 1.0.0 | Initialer Release |
 | 21.02.2024 | 1.0.4 | <ul><li>verpflichtende Angabe von</li><ul><li>`MessageHeader.id`</li><li>`MessageHeader.source`</li><li>`MessageHeader.source.name`</li><li>`MessageHeader.source.software`</li><li>`MessageHeader.source.version`</li><li>`MessageHeader.source.contact`</li></ul></ul><br> |
+| 07.03.2024 | 1.1.0 | Änderung des MessageHeaders zur Angabe von KIM-Adresse und TelematikID in `MessageHeader.source` und `MessageHeader.destination` |

--- a/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Handshake.page.md
+++ b/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Handshake.page.md
@@ -60,4 +60,4 @@ Hier beispielhaft ein Nachrichtenaustausch im Anwendungsfall ["E-Rezept Rezeptan
 
 ## Fehlerhandling
 
-Im MessageHeader ist unter .source anzugeben welche Software den Request abgesetzt hat. Falls die ankommenden Daten nicht validiert oder verarbeitet werden können, MUSS an dieser Stelle mindestens eine Kontaktmöglichkeit angegeben werden. So kann im Fehlerfall möglichst automatisiert ein Fehlerbericht an das sendende System übermittelt werden. Der Nutzer SOLL dann auch benachrichtigt werden, dass es zu einem Fehler kam und dass der Hersteller entsprechend informiert wurde.
+Im MessageHeader ist unter .source anzugeben welche Software den Request abgesetzt hat. Falls die ankommenden Daten nicht validiert oder verarbeitet werden können, soll es hier die Möglichkeit geben mindestens eine E-Mail anzugeben. So kann im Fehlerfall möglichst automatisiert ein Fehlerbericht an das sendende System übermittelt werden. Der Nutzer SOLL dann auch benachrichtigt werden, dass es zu einem Fehler kam und der Hersteller entsprechend informiert wurde.

--- a/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Handshake.page.md
+++ b/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Handshake.page.md
@@ -60,4 +60,4 @@ Hier beispielhaft ein Nachrichtenaustausch im Anwendungsfall ["E-Rezept Rezeptan
 
 ## Fehlerhandling
 
-Im MessageHeader ist unter .source anzugeben welche Software den Request abgesetzt hat. Falls die ankommenden Daten nicht validiert oder verarbeitet werden können, soll es hier die Möglichkeit geben mindestens eine E-Mail anzugeben. So kann im Fehlerfall möglichst automatisiert ein Fehlerbericht an das sendende System übermittelt werden. Der Nutzer SOLL dann auch benachrichtigt werden, dass es zu einem Fehler kam und der Hersteller entsprechend informiert wurde.
+Im MessageHeader ist unter .source anzugeben welche Software den Request abgesetzt hat. Falls die ankommenden Daten nicht validiert oder verarbeitet werden können, MUSS an dieser Stelle mindestens eine Kontaktmöglichkeit angegeben werden. So kann im Fehlerfall möglichst automatisiert ein Fehlerbericht an das sendende System übermittelt werden. Der Nutzer SOLL dann auch benachrichtigt werden, dass es zu einem Fehler kam und dass der Hersteller entsprechend informiert wurde.

--- a/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Methodik.page.md
+++ b/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Methodik.page.md
@@ -1,3 +1,14 @@
 # {{page-title}}
 
+## Normen und Spezifikationen
 Anforderungen als Ausdruck normativer Festlegungen werden durch die dem [RFC2119](https://tools.ietf.org/html/rfc2119) entsprechenden, in Großbuchstaben geschriebenen deutschen Schlüsselworte MUSS, DARF NICHT, SOLL, SOLL NICHT, KANN sowie ihrer Pluralformen gekennzeichnet.
+
+## Must Support
+Felder der FHIR-Spezifikation, die mit "Must Support" (MS) geflaggt sind, SOLLEN derart umgesetzt werden, dass die Inhalte dem Nutzer sichtbar gemacht werden und wo nötig auch bearbeitbar sind.
+
+### Im Kontext des Erstellens von FHIR-Ressourcen
+Wenn die entsprechende Information vorliegt, bzw. eingeholt werden kann, MUSS dieses Feld befüllt werden.
+
+### Im Kontext des Verarbeitens von FHIR-Ressourcen
+Wenn ein Feld befüllt ist MUSS die entsprechende Information im Frontend sichtbar gemacht werden.
+Felder, die Referenzen zu anderen Objekten aufweisen und mit "MS" gekennzeichnet sind, MUSS das referenzierte Objekt verarbeiten und darstellen können.

--- a/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Methodik.page.md
+++ b/src/fhir/guides/ig-atf/Home/UebergreifendeFestlegungen/Methodik.page.md
@@ -4,7 +4,7 @@
 Anforderungen als Ausdruck normativer Festlegungen werden durch die dem [RFC2119](https://tools.ietf.org/html/rfc2119) entsprechenden, in Großbuchstaben geschriebenen deutschen Schlüsselworte MUSS, DARF NICHT, SOLL, SOLL NICHT, KANN sowie ihrer Pluralformen gekennzeichnet.
 
 ## Must Support
-Felder der FHIR-Spezifikation, die mit "Must Support" (MS) geflaggt sind, SOLLEN derart umgesetzt werden, dass die Inhalte dem Nutzer sichtbar gemacht werden und wo nötig auch bearbeitbar sind.
+Felder der FHIR-Spezifikation, die mit "Must Support" (MS) geflaggt sind, SOLLEN derart umgesetzt werden, dass die Inhalte dem Nutzer sichtbar gemacht werden und wo möglich auch bearbeitbar sind.
 
 ### Im Kontext des Erstellens von FHIR-Ressourcen
 Wenn die entsprechende Information vorliegt, bzw. eingeholt werden kann, MUSS dieses Feld befüllt werden.

--- a/src/fhir/guides/ig-atf/guide.yaml
+++ b/src/fhir/guides/ig-atf/guide.yaml
@@ -1,5 +1,5 @@
 title: App Transport Framework Implementation Guide
 description: ImplementationGuide zur Umsetzung des App Transport Framework
-version: 1.0.4
+version: 1.1.0
 style-root: styles
 style-name: twolevelmenu

--- a/src/fhir/input/fsh/aliases.fsh
+++ b/src/fhir/input/fsh/aliases.fsh
@@ -1,3 +1,4 @@
 Alias: $kim = http://gematik.de/fhir/sid/KIM-Adresse
 Alias: $tim = http://gematik.de/fhir/sid/TIM-Adresse
 Alias: $IssueTypeCS = http://hl7.org/fhir/issue-type
+Alias: $telematik-id = http://fhir.de/StructureDefinition/identifier-telematik-id

--- a/src/fhir/input/fsh/examples/Example_MessageBundle.fsh
+++ b/src/fhir/input/fsh/examples/Example_MessageBundle.fsh
@@ -21,9 +21,8 @@ Description: "Example MessageHeader for Selbsttest"
 * source.endpoint = "https://sender.example.com/endpoint"
 * sender.identifier = ExampleKimAddress
 * sender.display = "Sender Example"
-* destination.endpoint = "https://receiver.example.com/endpoint"
-* destination.receiver.identifier.system = $kim
-* destination.receiver.identifier.value = "receiver@example.klaus.kim.telematik"
+* destination.endpoint = "mailto:receiver@example.klaus.kim.telematik"
+* destination.receiver.identifier = ExampleTelematikIdIdentifier
 * destination.receiver.display = "Receiver Example"
 * focus.reference = "urn:uuid:86a87254-ce15-11ed-afa1-0242ac120004"
 * source.name = "TopDoc Systems"
@@ -33,6 +32,12 @@ Description: "Example MessageHeader for Selbsttest"
 * source.contact
   * system = #email
   * value = "support@topdoc-systems.de"
+
+Instance: ExampleTelematikIdIdentifier
+InstanceOf: $telematik-id
+Usage: #inline
+Title: "Example Identifier with TelematikID"
+* value = "3-test-receiver"
 
 Instance: ExampleCommunication
 InstanceOf: Communication

--- a/src/fhir/input/fsh/examples/Example_MessageBundle.fsh
+++ b/src/fhir/input/fsh/examples/Example_MessageBundle.fsh
@@ -18,7 +18,6 @@ Usage: #example
 Title: "Example MessageHeader"
 Description: "Example MessageHeader for Selbsttest"
 * eventCoding = ServiceIdentifierCS#atf;Selbsttest
-* source.endpoint = "https://sender.example.com/endpoint"
 * sender.identifier = ExampleKimAddress
 * sender.display = "Sender Example"
 * destination.endpoint = "mailto:receiver@example.klaus.kim.telematik"
@@ -28,7 +27,7 @@ Description: "Example MessageHeader for Selbsttest"
 * source.name = "TopDoc Systems"
 * source.software = "TopDoc TI"
 * source.version = "2.4.5"
-* source.endpoint = "https://topdoc-systems.de"
+* source.endpoint = "mailto:sender@example.peter.kim.telematik"
 * source.contact
   * system = #email
   * value = "support@topdoc-systems.de"

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -44,7 +44,7 @@ Description: "MessageHeader des MessageBundles"
     * ^short = "Version der Software"
     * ^comment = "Diese Infomation ist verpflichtend, um das sendende System identifizieren zu können"
   * contact 1..1 MS
-    * ^short = "Kontaktinformation zum Hersteller" //TODO: Mit Robert klären, ob E-Mail verpflichtend anzugeben ist
+    * ^short = "Kontaktinformation zum Hersteller"
     * ^comment = "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden"
   * endpoint MS
     * ^short = "KIM-Adresse des Absenders"

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -51,4 +51,3 @@ Description: "MessageHeader des MessageBundles"
     * ^comment = "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist."
 
 //TODO Für IG und Instances: Referenzpunkt display als Anzeigename
-//TODO Für IG und Instances: Im source.endpoint und destination.endpoint 1..1, sollten diese als KIM Adresse genutzt werden! Diese müssten mit "mailto:" beginnen, da der Datentyp url ist.

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -13,22 +13,24 @@ Description: "MessageHeader des MessageBundles"
 // Sender
 * sender 1..1 MS
 * sender.identifier 1..1 MS
+  * ^short = "Telematik-ID des Absenders"
 * sender.identifier only $telematik-id
 * sender.display 0..1 MS
-  * ^short = "Anzeigename des Senders"
+  * ^short = "Anzeigename des Absenders"
 
 // Empfänger
 * destination 1..* MS
 * destination.receiver 1..1
+  * ^short = "Telematik-ID des Empfängers"
 * destination.receiver.identifier 1..1 MS
 * destination.receiver.identifier only $telematik-id
 * destination.receiver.display 0..1 MS
   * ^short = "Anzeigename des Empfängers"
 * destination.endpoint MS
-  * ^short = "KIM-Adresse des Empfängers"
-  * ^comment = "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist."
+  * ^short = "Bspw. KIM- oder TIM-Adresse des Empfängers"
+  * ^comment = "Die FHIR Ressource sieht hier eine URL vor. Bspw. kann hier eine KIM-Adresse genutzt werden. Diese beginnt mit 'mailto:', da der Datentyp url ist."
 
-* focus 1..*
+* focus 1..* MS
 
 // Quelle der Nachricht
 * source MS
@@ -47,7 +49,7 @@ Description: "MessageHeader des MessageBundles"
     * ^short = "Kontaktinformation zum Hersteller"
     * ^comment = "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden"
   * endpoint MS
-    * ^short = "KIM-Adresse des Absenders"
-    * ^comment = "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist."
+    * ^short = "Bspw. KIM- oder TIM-Adresse des Absenders"
+    * ^comment = "Die FHIR Ressource sieht hier eine URL vor. Bspw. kann hier eine KIM-Adresse genutzt werden. Diese beginnt mit 'mailto:', da der Datentyp url ist."
 
 //TODO Für IG und Instances: Referenzpunkt display als Anzeigename

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -10,19 +10,27 @@ Description: "MessageHeader des MessageBundles"
 * id 1..1 MS
   * ^short = "Eindeutige ID der Nachricht, anzugeben als UUID"
 
+// Sender
 * sender 1..1 MS
 * sender.identifier 1..1 MS
-* sender.identifier only IdentifierAddressKIM or IdentifierAddressTIM
+* sender.identifier only $telematik-id
 * sender.display 0..1 MS
-  * ^short = "Anzeigename der Absender Adresse"
+  * ^short = "Anzeigename des Senders"
+
+// Empfänger
 * destination 1..* MS
 * destination.receiver 1..1
 * destination.receiver.identifier 1..1 MS
-* destination.receiver.identifier only IdentifierAddressKIM or IdentifierAddressTIM
+* destination.receiver.identifier only $telematik-id
 * destination.receiver.display 0..1 MS
-  * ^short = "Anzeigename der Empfänger Adresse"
+  * ^short = "Anzeigename des Empfängers"
+* destination.endpoint MS
+  * ^short = "KIM-Adresse des Empfängers"
+  * ^comment = "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist."
+
 * focus 1..*
 
+// Quelle der Nachricht
 * source MS
   * ^short = "Angabe der Informationen des Absendenden Systems"
   * ^comment = "Diese Infomation ist verpflichtend"
@@ -36,8 +44,11 @@ Description: "MessageHeader des MessageBundles"
     * ^short = "Version der Software"
     * ^comment = "Diese Infomation ist verpflichtend, um das sendende System identifizieren zu können"
   * contact 1..1 MS
-    * ^short = "Kontaktinformation zum Hersteller"
-    * ^comment = "Es ist mindestens eine Email anzugeben, um Kontakt mit dem Hersteller herzustellen"
+    * ^short = "Kontaktinformation zum Hersteller" //TODO: Mit Robert klären, ob E-Mail verpflichtend anzugeben ist
+    * ^comment = "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden"
+  * endpoint MS
+    * ^short = "KIM-Adresse des Absenders"
+    * ^comment = "Die FHIR Ressource sieht hier eine URL vor, die als KIM-Adresse genutzt werden kann. Diese beginnt mit 'mailto:', da der Datentyp url ist."
 
 //TODO Für IG und Instances: Referenzpunkt display als Anzeigename
 //TODO Für IG und Instances: Im source.endpoint und destination.endpoint 1..1, sollten diese als KIM Adresse genutzt werden! Diese müssten mit "mailto:" beginnen, da der Datentyp url ist.

--- a/src/fhir/input/fsh/profiles/MessageHeader.fsh
+++ b/src/fhir/input/fsh/profiles/MessageHeader.fsh
@@ -46,8 +46,9 @@ Description: "MessageHeader des MessageBundles"
     * ^short = "Version der Software"
     * ^comment = "Diese Infomation ist verpflichtend, um das sendende System identifizieren zu können"
   * contact 1..1 MS
-    * ^short = "Kontaktinformation zum Hersteller"
-    * ^comment = "Es muss eine Kontaktmöglichkeit zum Hersteller angegeben werden"
+    * ^short = "E-Mail Kontaktmöglichkeit zum Hersteller"
+    * ^comment = "Es ist mindestens eine E-Mail anzugeben, um Kontakt mit dem Hersteller herstellen zu können"
+    * system = #email (exactly)
   * endpoint MS
     * ^short = "Bspw. KIM- oder TIM-Adresse des Absenders"
     * ^comment = "Die FHIR Ressource sieht hier eine URL vor. Bspw. kann hier eine KIM-Adresse genutzt werden. Diese beginnt mit 'mailto:', da der Datentyp url ist."

--- a/src/fhir/sushi-config.yaml
+++ b/src/fhir/sushi-config.yaml
@@ -2,7 +2,7 @@ canonical: https://gematik.de/fhir/atf
 fhirVersion: 4.0.1 # https://www.hl7.org/fhir/valueset-FHIR-version.html
 applyExtensionMetadataToRoot: false
 FSHOnly: true
-version: 1.0.4
+version: 1.1.0
 dependencies:
   hl7.fhir.r4.core: 4.0.1
   de.basisprofil.r4: 1.4.0

--- a/src/fhir/sushi-config.yaml
+++ b/src/fhir/sushi-config.yaml
@@ -5,3 +5,4 @@ FSHOnly: true
 version: 1.0.4
 dependencies:
   hl7.fhir.r4.core: 4.0.1
+  de.basisprofil.r4: 1.4.0


### PR DESCRIPTION
Es wurde festgelegt, dass im MessageHeader des ATF die KIM Adresse und die TelematikID des Senders und Empfängers anzugeben sind.
Diese Änderungen wurden hier angepasst. Da es sich um einen breaking change handelt wurde die Version auf 1.1.0 erhöht.